### PR TITLE
Add PREFERRED_PROTOCOL and LIGHTWAY_CIPHER

### DIFF
--- a/expressvpn/Dockerfile
+++ b/expressvpn/Dockerfile
@@ -7,6 +7,12 @@ LABEL maintainer="benjamin@polkaned.net"
 
 ENV ACTIVATION_CODE Code
 ENV LOCATION smart
+
+# auto, udp, tcp, lightway_udp, lightway_tcp
+ENV PREFERRED_PROTOCOL auto
+# auto, aes, chacha20
+ENV LIGHTWAY_CIPHER auto
+
 ARG APP=expressvpn_3.7.0.29-1_amd64.deb
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/expressvpn/README.md
+++ b/expressvpn/README.md
@@ -15,6 +15,8 @@ This container should be used as base layer.
     docker run \
       --env=ACTIVATION_CODE={% your-activation-code %} \
       --env=SERVER={% LOCATION/ALIAS/COUNTRY %} \
+      --env=PREFERRED_PROTOCOL={% auto, udp, tcp, lightway_udp, lightway_tcp %} \
+      --env=LIGHTWAY_CIPHER={% auto, aes, chacha20 %} \
       --cap-add=NET_ADMIN \
       --device=/dev/net/tun \
       --privileged \
@@ -36,6 +38,8 @@ In this case all traffic is routed via the vpn container. To reach the other con
     environment:
       - ACTIVATION_CODE={% your-activation-code %}
       - SERVER={% LOCATION/ALIAS/COUNTRY %}
+      - PREFERRED_PROTOCOL={% auto, udp, tcp, lightway_udp, lightway_tcp %}
+      - LIGHTWAY_CIPHER={% auto, aes, chacha20 %}
     cap_add:
       - NET_ADMIN
     devices: 

--- a/expressvpn/entrypoint.sh
+++ b/expressvpn/entrypoint.sh
@@ -6,6 +6,7 @@ cp /tmp/resolv.conf /etc/resolv.conf
 sed -i 's/DAEMON_ARGS=.*/DAEMON_ARGS=""/' /etc/init.d/expressvpn
 service expressvpn restart
 /usr/bin/expect /tmp/expressvpnActivate.sh
+expressvpn preferences set auto_connect true
 expressvpn preferences set preferred_protocol $PREFERRED_PROTOCOL
 expressvpn preferences set lightway_cipher $LIGHTWAY_CIPHER
 expressvpn connect $SERVER

--- a/expressvpn/entrypoint.sh
+++ b/expressvpn/entrypoint.sh
@@ -6,5 +6,7 @@ cp /tmp/resolv.conf /etc/resolv.conf
 sed -i 's/DAEMON_ARGS=.*/DAEMON_ARGS=""/' /etc/init.d/expressvpn
 service expressvpn restart
 /usr/bin/expect /tmp/expressvpnActivate.sh
+expressvpn preferences set preferred_protocol $PREFERRED_PROTOCOL
+expressvpn preferences set lightway_cipher $LIGHTWAY_CIPHER
 expressvpn connect $SERVER
 exec "$@"


### PR DESCRIPTION
I added these two environment variables so that you can set the protocol and cipher!

I did this mainly so I can ensure `lightway_udp` and `chacha20` to get the best speed.

If you build and run this:

```
docker run \
	--env=ACTIVATION_CODE={% your-activation-code %} \
	--env=SERVER=smart \
	--env=PREFERRED_PROTOCOL=tcp \
	--env=LIGHTWAY_CIPHER=aes \
	--cap-add=NET_ADMIN \
	--device=/dev/net/tun \
	--privileged \
	--rm -it \
	polkaned/expressvpn \
	/bin/bash
```

You can check the preferences set with `expressvpn preferences`

And the diagnostics/logs with `expressvpn diagnostics` which will be very different when using `lightway_udp` compared to `tcp` (openvpn)

Thanks for the awesome Docker image! I learned about `network_mode: service:expressvpn` today too haha

Edit: I also added `auto_connect` to true. It was set to false by default.