### PR TITLE
Add healthcheck and logic in entrypoint

### DIFF
--- a/expressvpn/Dockerfile
+++ b/expressvpn/Dockerfile
@@ -23,4 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY entrypoint.sh /tmp/entrypoint.sh
 COPY expressvpnActivate.sh /tmp/expressvpnActivate.sh
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=3 CMD if expressvpn status | grep -q Connected;then true;else false;fi || exit 1
+
 ENTRYPOINT ["/bin/bash", "/tmp/entrypoint.sh"]

--- a/expressvpn/entrypoint.sh
+++ b/expressvpn/entrypoint.sh
@@ -5,9 +5,38 @@ su -c 'umount /etc/resolv.conf'
 cp /tmp/resolv.conf /etc/resolv.conf
 sed -i 's/DAEMON_ARGS=.*/DAEMON_ARGS=""/' /etc/init.d/expressvpn
 service expressvpn restart
-/usr/bin/expect /tmp/expressvpnActivate.sh
-expressvpn preferences set auto_connect true
-expressvpn preferences set preferred_protocol $PREFERRED_PROTOCOL
-expressvpn preferences set lightway_cipher $LIGHTWAY_CIPHER
-expressvpn connect $SERVER
-exec "$@"
+sleep 5 #wait for service to start to see if it has already been activated
+if expressvpn status | grep -q "Not connected"
+then
+    echo "Already Activated!"
+elif expressvpn status | grep -q "Connected"
+then
+    echo "Already Connected!"
+else
+    /usr/bin/expect /tmp/expressvpnActivate.sh
+    x=1 #sleep for up to 60 seconds while the activate script runs
+    while [ $x -le 60 ]
+    do
+    if expressvpn status | grep -q "Not Activated"
+    then
+        sleep 1
+    else
+        x=61
+    fi
+    x=$(( $x + 1 ))
+    done
+fi
+if expressvpn status | grep -q "Not Activated"
+then
+    echo "Failed to activate"
+    exit 1 #restart the container if actiavation failed
+elif expressvpn status | grep -q "Connected"
+then
+    echo "Already Connected!"
+else
+    expressvpn preferences set auto_connect true
+    expressvpn preferences set preferred_protocol $PREFERRED_PROTOCOL
+    expressvpn preferences set lightway_cipher $LIGHTWAY_CIPHER
+    expressvpn connect $SERVER
+    exec "$@"
+fi


### PR DESCRIPTION
This PR will add a health check to the container to flag if it is connected to the VPN (healthy) by checking the service and looking for "connected" and if "Not connected" will flag it as unhealthy. It also adds some logic around when to call the activation script as it is only needed the first time a container is created, if it is restarted it will show errors as it tries to input the activation key to unexpected input fields. 